### PR TITLE
Crash on ack error

### DIFF
--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -67,7 +67,7 @@ defmodule BroadwaySQS.ExAwsClient do
 
     opts.queue_url
     |> ExAws.SQS.delete_message_batch(receipts)
-    |> ExAws.request(opts.config)
+    |> ExAws.request!(opts.config)
   end
 
   defp wrap_received_messages({:ok, %{body: body}}, ack_ref) do


### PR DESCRIPTION
Closes #42

Before this patch we were silently ignoring ack failures. With this change, the failure will be logged in the processor ([link](https://github.com/dashbitco/broadway/blob/v0.5.0/lib/broadway/processor.ex#L59))

We use `ExAws.request` (non-bang version) in only one other place ([link](https://github.com/dashbitco/broadway_sqs/blob/v0.5.0/lib/broadway_sqs/ex_aws_client.ex#L50)) however we're correctly unwrapping result and logging an error. We could change that callsite to use `request!` too, but I wasn't sure if it was important to gracefully handle that failure and return `[]`, see ([link](https://github.com/dashbitco/broadway_sqs/blob/v0.5.0/test/broadway_sqs/ex_aws_client_test.exs#L342:L343)), so I decided not to change that.