### PR TITLE
Feature/acknowledger impl

### DIFF
--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -80,9 +80,9 @@ defmodule BroadwaySQS.ExAwsClient do
   end
 
   @impl Acknowledger
-  def configure(_ack_ref, ack_options, options) do
+  def configure(_ack_ref, ack_data, options) do
     validate_configure_options!(options)
-    {:ok, Map.merge(ack_options, Map.new(options))}
+    {:ok, Map.merge(ack_data, Map.new(options))}
   end
 
   defp validate_configure_options!(options) do

--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -61,7 +61,7 @@ defmodule BroadwaySQS.ExAwsClient do
     |> wrap_received_messages(opts.ack_ref)
   end
 
-  @impl true
+  @impl Acknowledger
   def ack(ack_ref, successful, failed) do
     ack_options = Broadway.TermStorage.get!(ack_ref)
 
@@ -79,7 +79,7 @@ defmodule BroadwaySQS.ExAwsClient do
     (message_ack_options[option] || Map.fetch!(ack_options, option)) == :ack
   end
 
-  @impl true
+  @impl Acknowledger
   def configure(_ack_ref, ack_options, options) do
     validate_configure_options!(options)
     {:ok, Map.merge(ack_options, Map.new(options))}


### PR DESCRIPTION
# Changes

Two small changes for the sake of clarity:

* Explicitly state which functions implement broadway behaviour
* Use the same variable names as Broadway's callbacks

In the [SQS producer](https://github.com/dashbitco/broadway_sqs/blob/master/lib/broadway_sqs/producer.ex) there is already an `@impl Producer` line to make the distinction of where the behaviour is defined. I figured it would be worth being consistent. 

# Summary

I've been reading in-detail through Broadway implementations to wrap my head around how they work.  For the sake of the next person who looks at the code, I thought it would be worthwhile to clarify which behaviours are being implemented. 