### PR TITLE
Make `wait_time_seconds` a 0-20 type_bounded_integer

### DIFF
--- a/lib/broadway_sqs/options.ex
+++ b/lib/broadway_sqs/options.ex
@@ -76,11 +76,17 @@ defmodule BroadwaySQS.Options do
         """
       ],
       wait_time_seconds: [
-        type: :non_neg_integer,
+        type: {
+          :custom,
+          __MODULE__,
+          :type_bounded_integer,
+          [[{:name, :wait_time_seconds}, {:min, 0}, {:max, 20}]]
+        },
         doc: """
         The duration (in seconds) for which the call waits
-        for a message to arrive in the queue before returning. For more information see
-         ["WaitTimeSeconds" on the Amazon SQS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html).
+        for a message to arrive in the queue before returning. This value must be
+        between `0` and `20`, which is the maximum number allowed by AWS. For more
+        information see ["WaitTimeSeconds" on the Amazon SQS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html).
         """
       ],
       visibility_timeout: [

--- a/test/broadway_sqs/producer_test.exs
+++ b/test/broadway_sqs/producer_test.exs
@@ -326,7 +326,7 @@ defmodule BroadwaySQS.BroadwaySQS.ProducerTest do
 
       assert_raise(
         ArgumentError,
-        ~r/expected :wait_time_seconds to be a non negative integer, got: -1/,
+        ~r/expected :wait_time_seconds to be an integer between 0 and 20, got: -1/,
         fn ->
           prepare_for_start_module_opts(
             queue_url: "https://sqs.amazonaws.com/0000000000/my_queue",
@@ -337,7 +337,7 @@ defmodule BroadwaySQS.BroadwaySQS.ProducerTest do
 
       assert_raise(
         ArgumentError,
-        ~r/expected :wait_time_seconds to be a non negative integer, got: :an_atom/,
+        ~r/expected :wait_time_seconds to be an integer between 0 and 20, got: :an_atom/,
         fn ->
           prepare_for_start_module_opts(
             queue_url: "https://sqs.amazonaws.com/0000000000/my_queue",


### PR DESCRIPTION
See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-queue-parameters.html

"For a standard queue, enter a value for Receive message wait time. The
range is 0 to 20 seconds. The default value is 0 seconds, which sets
short polling. Any non-zero value sets long polling. "


I wonder if the broadway SQS docs should go into long/short polling? I only found out
long polling was implemented through https://selleo.com/til/posts/umucqmead6-long-polling-in-broadwaysqs 
