### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v0.7.1 (2022-03-25)
+## v0.7.1 (2022-03-27)
 
-  * Optionally on newer version of nimble_options
+  * Relax `nimble_options` dependency to accept `~> 0.4.0`
    
 ## v0.7.0 (2021-08-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.1 (2022-03-25)
+
+  * Optionally on newer version of nimble_options
+   
 ## v0.7.0 (2021-08-30)
 
   * Add the following telemetry events:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ client of your choice (defaults to `:hackney`):
 ```elixir
 def deps do
   [
-    {:broadway_sqs, "~> 0.7.0"},
+    {:broadway_sqs, "~> 0.7.1"},
     {:hackney, "~> 1.9"}
   ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BroadwaySqs.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.7.1"
   @description "A SQS connector for Broadway"
 
   def project do


### PR DESCRIPTION
Hi! Thanks for this great library, we've been enjoying using them. This just a minor version bump, aimed at facilitating a release so that we can pickup the `nimble_options` update (6aad44956a018811792693347897799af2a888cd).

Hope it makes sense. I checked previous PRs for releases for guidance.