### PR TITLE
Create 0.7.2 release with new nimble_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.2 (2022-11-13)
+
+  * Relax `nimble_options` dependency to accept `~> 0.5.0`
+
 ## v0.7.1 (2022-03-27)
 
   * Relax `nimble_options` dependency to accept `~> 0.4.0`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ client of your choice (defaults to `:hackney`):
 ```elixir
 def deps do
   [
-    {:broadway_sqs, "~> 0.7.1"},
+    {:broadway_sqs, "~> 0.7.2"},
     {:hackney, "~> 1.9"}
   ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BroadwaySqs.MixProject do
   use Mix.Project
 
-  @version "0.7.1"
+  @version "0.7.2"
   @description "A SQS connector for Broadway"
 
   def project do


### PR DESCRIPTION
This creates a release allowing newer nimble_options (see #71).