### PR TITLE
Allow usage of nimble_options 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule BroadwaySqs.MixProject do
     [
       {:broadway, "~> 1.0"},
       {:ex_aws_sqs, "~> 3.2.1 or ~> 3.3"},
-      {:nimble_options, "~> 0.3.0 or ~> 0.4.0 or ~> 0.5.0"},
+      {:nimble_options, "~> 0.3.7 or ~> 0.4 or ~> 1.0"},
       {:telemetry, "~> 0.4.3 or ~> 1.0"},
       {:saxy, "~> 1.1"},
       {:hackney, "~> 1.9", only: [:dev, :test]},


### PR DESCRIPTION
I changed the requirements to match Broadway: https://github.com/dashbitco/broadway/blob/24533d4cc9ee23827cf289e6630f514c975ad922/mix.exs#LL31C39-L31C39