### PR TITLE
Fix code format to unblock CI

### DIFF
--- a/lib/broadway_sqs/options.ex
+++ b/lib/broadway_sqs/options.ex
@@ -220,9 +220,7 @@ defmodule BroadwaySQS.Options do
       {:ok, value}
     else
       {:error,
-       "expected :#{name} to be a list with possible members #{inspect(allowed_members)}, got: #{
-         inspect(value)
-       }"}
+       "expected :#{name} to be a list with possible members #{inspect(allowed_members)}, got: #{inspect(value)}"}
     end
   end
 end

--- a/test/broadway_sqs/producer_test.exs
+++ b/test/broadway_sqs/producer_test.exs
@@ -87,7 +87,8 @@ defmodule BroadwaySQS.BroadwaySQS.ProducerTest do
 
   describe "prepare_for_start/2 validation" do
     test "when the queue url is not present" do
-      message = "invalid configuration given to SQSBroadway.prepare_for_start/2, required :queue_url option not found, received options: []"
+      message =
+        "invalid configuration given to SQSBroadway.prepare_for_start/2, required :queue_url option not found, received options: []"
 
       assert_raise(ArgumentError, message, fn ->
         prepare_for_start_module_opts([])


### PR DESCRIPTION
This is simply a code format change just to unblock the CI pipeline that requires `mix format --check-formatted`.